### PR TITLE
fix(#57): [REGRESIÓN] Botón hamburguesa no abre el menú

### DIFF
--- a/src/app/views/cliente/ts/landing.ts
+++ b/src/app/views/cliente/ts/landing.ts
@@ -9,10 +9,11 @@ $(() => {
             generarCarrusel("js-carrusel")
         }
     )
-    $('.js-boton-menu').on('click', () => {
-        $('.js-menu').toggleClass('c-menu--oculto');
-    });
 })
+
+$('.js-boton-menu').on('click', () => {
+    $('.js-menu').toggleClass('c-menu--oculto');
+});
 
 function cargarDatosDesde(url) {
     return $.getJSON(url).then(


### PR DESCRIPTION
Fixes #57 

Regresión hallada en: 94d5c693bdcf94c6bcfa0b83a50431fe4f3307c1

Hotfix, habría que investigar la causa principal: el ready de jQuery se ejecuta 2 veces.