### PR TITLE
fix(#130): Margen de click de botones de cabecera

### DIFF
--- a/src/cliente/index.html
+++ b/src/cliente/index.html
@@ -30,8 +30,8 @@
                     </h1>
                 </div>
                 <div class="c-cabecera__botones">
-                    <i class="fas fa-user"></i>
-                    <i class="fas fa-shopping-cart"></i>
+                    <i class="c-cabecera__boton fas fa-user"></i>
+                    <i class="c-cabecera__boton fas fa-shopping-cart"></i>
                 </div>
             </div>
         </div>

--- a/src/cliente/index.html
+++ b/src/cliente/index.html
@@ -18,7 +18,11 @@
     <div class="l-distribucion">
         <div class="l-distribucion__cabecera">
             <div class="c-cabecera">
-                <div class="c-cabecera__boton-menu js-boton-menu"><i class="fas fa-bars"></i></div>
+                <div class="c-cabecera__boton-menu js-boton-menu">                    
+                    <div class="c-cabecera__boton">
+                        <i class="fas fa-bars"></i>
+                    </div>
+                </div>
                 <div class="c-cabecera__logo">
                     <h1 class="c-logo">
                         <span class="c-logo__parte">W</span><span class="c-logo__parte c-logo__parte--alterna">F</span>
@@ -30,8 +34,12 @@
                     </h1>
                 </div>
                 <div class="c-cabecera__botones">
-                    <i class="c-cabecera__boton fas fa-user"></i>
-                    <i class="c-cabecera__boton fas fa-shopping-cart"></i>
+                    <div class="c-cabecera__boton">
+                        <i class="fas fa-user"></i>
+                    </div>
+                    <div class="c-cabecera__boton">
+                        <i class="fas fa-shopping-cart"></i>                        
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/cliente/scss/components/_cabecera.scss
+++ b/src/cliente/scss/components/_cabecera.scss
@@ -36,7 +36,7 @@
     grid-auto-flow: column;
     font-size: 20px;
     @media only screen and (min-width: $mobile-l) {
-        gap: 10px;
+        gap: 20px;
     } 
 }
 

--- a/src/cliente/scss/components/_cabecera.scss
+++ b/src/cliente/scss/components/_cabecera.scss
@@ -10,7 +10,6 @@
 
 .c-cabecera__boton-menu {
     display: block;
-    padding: 15px;
     @media only screen and (min-width: $mobile-l) {
         display: none;
     }
@@ -42,5 +41,9 @@
 }
 
 .c-cabecera__boton {
-    padding: 15px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 50px;
+    width: 50px;
 }

--- a/src/cliente/scss/components/_cabecera.scss
+++ b/src/cliente/scss/components/_cabecera.scss
@@ -1,7 +1,6 @@
 .c-cabecera {
     display: flex;
     align-items: center;
-    padding: 10px 20px;
 
     background: $almendraBlanca;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
@@ -11,6 +10,7 @@
 
 .c-cabecera__boton-menu {
     display: block;
+    padding: 15px;
     @media only screen and (min-width: $mobile-l) {
         display: none;
     }
@@ -35,9 +35,12 @@
 .c-cabecera__botones {
     display: grid;
     grid-auto-flow: column;
-    gap: 15px;
-    @media only screen and (min-width: $mobile-l) {
-        gap: 30px;
-    }    
     font-size: 20px;
+    @media only screen and (min-width: $mobile-l) {
+        gap: 10px;
+    } 
+}
+
+.c-cabecera__boton {
+    padding: 15px;
 }

--- a/src/cliente/scss/components/_cabecera.scss
+++ b/src/cliente/scss/components/_cabecera.scss
@@ -36,7 +36,7 @@
     grid-auto-flow: column;
     font-size: 20px;
     @media only screen and (min-width: $mobile-l) {
-        gap: 20px;
+        gap: 10px;
     } 
 }
 

--- a/src/cliente/scss/components/_cabecera.scss
+++ b/src/cliente/scss/components/_cabecera.scss
@@ -11,8 +11,6 @@
 
 .c-cabecera__boton-menu {
     display: block;
-    padding: 10px 20px;
-    margin: -10px 0px -10px -20px;
     @media only screen and (min-width: $mobile-l) {
         display: none;
     }


### PR DESCRIPTION
Fixes #130 

Haciéndolo me he fijado en que un `i` de Font Awesome no siempre mide lo mismo, por lo que de aplicar `padding` a cada boton de forma individual se podrían descentrar. 

He creado un elemento `c-cabecera__boton` que tiene una altura y anchura fijos, y centra el `i` con flexbox para evitarlo.

---

En un futuro quizás sería buena idea extraer ese elemento a un componente, para evitar repetir el añadir margen alrededor de un icono que sea pulsable