### PR TITLE
fix(#177): [JS] Agregar producto por ventana modal no actualiza el botón en el grid

### DIFF
--- a/src/cliente/js/componentes/carrito.js
+++ b/src/cliente/js/componentes/carrito.js
@@ -27,6 +27,7 @@ function carrito_Actualizar() {
 function carrito_AñadirArticulo(id) {
     var producto = GLOBAL_GESTOR_PRODUCTOS.getProductoId(id)
     carrito.añadirProducto(producto)
+    $(`.c-producto[data-id=${id}] .c-producto__carrito`).addClass("c-producto__carrito--en-carrito");
     carrito_Actualizar()
     producto = carrito.getArticulo(producto.id)
     if (producto.cantidad > 1) {
@@ -48,10 +49,7 @@ function carrito_AñadirArticulo(id) {
         setTimeout(()=>{$(".js-cabecera-notificacion").addClass("c-cabecera__notificacion-animacion")},10)
     }
 }
-function carrito_Añadir(evento) {
-    $(this).addClass("c-producto__carrito--en-carrito")
-    carrito_AñadirArticulo($(this).parent().data('id'))
-}
+
 function carrito_ProcesarArticulo(articulo) {
     var html = `<p data-id='` + articulo.id + `' class='c-carrito__articulo'>
     <span class='c-carrito__nombre js-carrito-nombre'>`+ articulo.nombre + `</span>

--- a/src/cliente/js/componentes/carrito.js
+++ b/src/cliente/js/componentes/carrito.js
@@ -24,9 +24,10 @@ function carrito_Actualizar() {
     $(".c-carrito").html(html)
     carrito_ActualizarTriggers()
 }
-function carrito_AñadirArticulo(evento) {
-    $(this).addClass("c-producto__carrito--en-carrito")
-    var producto = GLOBAL_GESTOR_PRODUCTOS.getProductoId($(this).parent().data('id'))
+function carrito_AñadirArticulo(id) {
+    var producto = GLOBAL_GESTOR_PRODUCTOS.getProductoId(id)
+    console.log("ID",id)
+    console.log("PRODUCTO",producto)
     carrito.añadirProducto(producto)
     carrito_Actualizar()
     producto = carrito.getArticulo(producto.id)
@@ -48,6 +49,10 @@ function carrito_AñadirArticulo(evento) {
         $(".js-cabecera-notificacion").removeClass("c-cabecera__notificacion-animacion")
         setTimeout(()=>{$(".js-cabecera-notificacion").addClass("c-cabecera__notificacion-animacion")},10)
     }
+}
+function carrito_Añadir(evento) {
+    $(this).addClass("c-producto__carrito--en-carrito")
+    carrito_AñadirArticulo($(this).parent().data('id'))
 }
 function carrito_ProcesarArticulo(articulo) {
     var html = `<p data-id='` + articulo.id + `' class='c-carrito__articulo'>

--- a/src/cliente/js/componentes/carrito.js
+++ b/src/cliente/js/componentes/carrito.js
@@ -26,8 +26,6 @@ function carrito_Actualizar() {
 }
 function carrito_AñadirArticulo(id) {
     var producto = GLOBAL_GESTOR_PRODUCTOS.getProductoId(id)
-    console.log("ID",id)
-    console.log("PRODUCTO",producto)
     carrito.añadirProducto(producto)
     carrito_Actualizar()
     producto = carrito.getArticulo(producto.id)

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -103,17 +103,7 @@ class GestorProductos {
         })
 
         $('.js-modal-producto_añadir-carrito').on('click', function () {
-            carrito.añadirProducto(producto);
-
-            let articulo = carrito.getArticulo(producto.id);
-            carrito_Actualizar();
-
-            if (articulo.cantidad > 1) {
-                generarNotificacion(articulo.nombre + " tienes " + articulo.cantidad + " unidades.", true);
-            } else {
-                generarNotificacion(articulo.nombre + " añadido al carrito.", true);
-            }
-
+            carrito_AñadirArticulo(producto.id);
             cerrarVentanaModal();
         });
     }

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -80,7 +80,7 @@ function vista_Productos_cargarDe(puntoMontaje, categoriaPrincipal, categoria) {
                 }
             }
         })
-        $(".js-producto-carrito").off('click').on('click', carrito_AñadirArticulo)
+        $(".js-producto-carrito").off('click').on('click', carrito_Añadir)
         $(".js-producto-imagen").on('click', vista_Productos_generarModal)
         if ($($(".js-productos-destacados")[0]).children().length < 1) {
             $(".js-productos-destacados").remove()

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -80,7 +80,9 @@ function vista_Productos_cargarDe(puntoMontaje, categoriaPrincipal, categoria) {
                 }
             }
         })
-        $(".js-producto-carrito").off('click').on('click', carrito_Añadir)
+        $(".js-producto-carrito").off('click').on('click', function() {
+            carrito_AñadirArticulo($(this).parent().data('id'));
+        })
         $(".js-producto-imagen").on('click', vista_Productos_generarModal)
         if ($($(".js-productos-destacados")[0]).children().length < 1) {
             $(".js-productos-destacados").remove()


### PR DESCRIPTION
Fixes #177 

En colaboración con @Hechix.

`carrito_AñadirArticulo` ahora acepta el id de producto, de forma que se puede añadir un producto sin importar el origen (evento, elemento...)  y actualizar la clase de este en el grid a "en carrito.