### PR TITLE
feat(#197) : Ofertas funcionales.

### DIFF
--- a/db/WeekFood.sql
+++ b/db/WeekFood.sql
@@ -87,7 +87,7 @@ CREATE TABLE `menu` (
 
 LOCK TABLES `menu` WRITE;
 /*!40000 ALTER TABLE `menu` DISABLE KEYS */;
-INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Productos','productos'),(3,'Alérgenos','alergenos');
+INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Ofertas destacadas','ofertas'),(3,'Productos','productos'),(4,'Alérgenos','alergenos');
 /*!40000 ALTER TABLE `menu` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/WeekFood.sql
+++ b/db/WeekFood.sql
@@ -87,7 +87,7 @@ CREATE TABLE `menu` (
 
 LOCK TABLES `menu` WRITE;
 /*!40000 ALTER TABLE `menu` DISABLE KEYS */;
-INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Ofertas destacadas','ofertas'),(3,'Productos','productos'),(4,'Alérgenos','alergenos');
+INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Productos','productos'),(3,'Alérgenos','alergenos');
 /*!40000 ALTER TABLE `menu` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/WeekFood.sql
+++ b/db/WeekFood.sql
@@ -87,7 +87,7 @@ CREATE TABLE `menu` (
 
 LOCK TABLES `menu` WRITE;
 /*!40000 ALTER TABLE `menu` DISABLE KEYS */;
-INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Productos','productos'),(3,'Alérgenos','alergenos');
+INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Productos','productos'),(3,'Quiénes somos','quienesSomos');
 /*!40000 ALTER TABLE `menu` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/WeekFood.sql
+++ b/db/WeekFood.sql
@@ -87,7 +87,7 @@ CREATE TABLE `menu` (
 
 LOCK TABLES `menu` WRITE;
 /*!40000 ALTER TABLE `menu` DISABLE KEYS */;
-INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Ofertas Destacadas','ofertas'),(3,'Productos','productos'),(4,'Alérgenos','alergenos');
+INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Ofertas Destacadas','ofertas'),(3,'Alérgenos','alergenos');
 /*!40000 ALTER TABLE `menu` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/WeekFood.sql
+++ b/db/WeekFood.sql
@@ -87,7 +87,7 @@ CREATE TABLE `menu` (
 
 LOCK TABLES `menu` WRITE;
 /*!40000 ALTER TABLE `menu` DISABLE KEYS */;
-INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Productos','productos'),(3,'Ofertas Destacadas','ofertas'),(4,'Alérgenos','alergenos');
+INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Ofertas Destacadas','ofertas'),(3,'Productos','productos'),(4,'Alérgenos','alergenos');
 /*!40000 ALTER TABLE `menu` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/db/WeekFood.sql
+++ b/db/WeekFood.sql
@@ -87,7 +87,7 @@ CREATE TABLE `menu` (
 
 LOCK TABLES `menu` WRITE;
 /*!40000 ALTER TABLE `menu` DISABLE KEYS */;
-INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Ofertas Destacadas','ofertas'),(3,'Alérgenos','alergenos');
+INSERT INTO `menu` VALUES (1,'Inicio','portada'),(2,'Productos','productos'),(3,'Alérgenos','alergenos');
 /*!40000 ALTER TABLE `menu` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -38,4 +38,10 @@ class ProductosResource extends Resource {
         $this->execSQL($params);
         $this->setData();
     }
+
+    public function getDestacadosAction() {
+        $this->sql = 'SELECT * FROM productos WHERE destacado = 1';
+        $this->execSQL();
+        $this->setData();
+    }
 }

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -40,8 +40,15 @@ class ProductosResource extends Resource {
     }
 
     public function getDestacadosAction() {
-        $this->sql = 'SELECT * FROM productos WHERE destacado = 1';
-        $this->execSQL();
+        if ($this->controller->getParam("destacado") !== '1'){
+            $this->setError(400, 'Petición incorrecta');
+            return false;
+        }
+        $params = [
+            "destacado" =>  $this->controller->getParam("destacado")
+        ];
+        $this->sql = 'SELECT * FROM productos WHERE destacado = :destacado';
+        $this->execSQL($params);
         $this->setData();
     }
 }

--- a/src/cliente/js/abstractos.js
+++ b/src/cliente/js/abstractos.js
@@ -1,7 +1,8 @@
 var GLOBAL_VISTAS = {
     error: vista_Error,
     portada: vista_Portada,
-    productos: vista_Productos
+    productos: vista_Productos,
+    ofertas: vista_Ofertas
 }
 var GLOBAL_VISTA_ACTUAL = "";
 var GLOBAL_CACHE_JSONS = new CacheJSONs();

--- a/src/cliente/js/abstractos.js
+++ b/src/cliente/js/abstractos.js
@@ -2,7 +2,7 @@ var GLOBAL_VISTAS = {
     error: vista_Error,
     portada: vista_Portada,
     productos: vista_Productos,
-    ofertas: vista_Ofertas
+    ofertas: vista_Productos_Ofertas
 }
 var GLOBAL_REDIRECCIONES = {
     productos:'ofertas',

--- a/src/cliente/js/abstractos.js
+++ b/src/cliente/js/abstractos.js
@@ -4,6 +4,10 @@ var GLOBAL_VISTAS = {
     productos: vista_Productos,
     ofertas: vista_Ofertas
 }
+var GLOBAL_REDIRECCIONES = {
+    productos:'ofertas',
+    ofertas:'ofertas',
+}
 var GLOBAL_VISTA_ACTUAL = "";
 var GLOBAL_CACHE_JSONS = new CacheJSONs();
 var GLOBAL_NOTIFICACION_TOP = null;

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -115,4 +115,18 @@ class GestorProductos {
             cerrarVentanaModal();
         });
     }
+
+    getProductosDestacados(){
+        if (this.productosDestacados.length > 0) {
+            return $.when(productosDestacados)
+        } else {
+            return GLOBAL_CACHE_JSONS.getJSON("/api/productos?destacados=1").then((respuesta) => {
+                respuesta.forEach(prod => {
+                    var nuevoProducto = new Producto(prod.id, prod.nombre, prod.foto, (prod.destacado == 1), prod.categoria.split(","), prod.descripcion, prod.precio)
+                    this.productosDestacados.push(nuevoProducto)
+                });
+                return this.productosDestacados
+            })
+        }
+    }
 }

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -40,9 +40,7 @@ class GestorProductos {
      * 
      */
     getCategoriasEnCategoriaPrincipal(categoriaPrincipal) {
-        console.log(categoriaPrincipal)
         var categoriaEncontrada = this.categoriasPrincipales.find(categoria => this.filtrarCategoriaPrincipal(categoriaPrincipal, categoria))
-        console.log(categoriaEncontrada)
         if (categoriaEncontrada == undefined) { return undefined }
         if (categoriaEncontrada.categorias.length > 0) {
             return $.when(categoriaEncontrada.categorias[0])

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -1,5 +1,6 @@
 class GestorProductos {
     constructor() {
+        this.seHaPedidoExplicitamenteDestacados = false
         this.productos = []
         this.categoriasPrincipales = []
         GLOBAL_CACHE_JSONS.getJSON("/api/productos/categorias/").then((categoriasPrincipales) => {
@@ -110,10 +111,11 @@ class GestorProductos {
 
     getProductosDestacados() {
         var productosFiltrados = this.productos.filter(producto => producto.destacado)
-        if (productosFiltrados.length > 0) {
+        if (productosFiltrados.length > 0 && this.seHaPedidoExplicitamenteDestacados) {
             return $.when(productosFiltrados)
         } else {
             return GLOBAL_CACHE_JSONS.getJSON("/api/productos?destacados=1").then((respuesta) => {
+                this.seHaPedidoExplicitamenteDestacados = true
                 var nuevosProductos = []
                 respuesta.forEach(prod => {
                     var nuevoProducto = new Producto(prod.id, prod.nombre, prod.foto, (prod.destacado == 1), prod.categoria.split(","), prod.descripcion, prod.precio)

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -116,7 +116,7 @@ class GestorProductos {
         if (productosFiltrados.length > 0 && this.seHaPedidoExplicitamenteDestacados) {
             return $.when(productosFiltrados)
         } else {
-            return GLOBAL_CACHE_JSONS.getJSON("/api/productos?destacados=1").then((respuesta) => {
+            return GLOBAL_CACHE_JSONS.getJSON("/api/productos?destacado=1").then((respuesta) => {
                 this.seHaPedidoExplicitamenteDestacados = true
                 var nuevosProductos = []
                 respuesta.forEach(prod => {

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -69,7 +69,9 @@ class GestorProductos {
                 var nuevosProductos = []
                 respuesta.forEach(prod => {
                     var nuevoProducto = new Producto(prod.id, prod.nombre, prod.foto, (prod.destacado == 1), prod.categoria.split(","), prod.descripcion, prod.precio)
-                    this.productos.push(nuevoProducto)
+                    if (this.getProductoId(nuevoProducto.id) == undefined){
+                        this.productos.push(nuevoProducto)
+                    }
                     nuevosProductos.push(nuevoProducto)
                 });
                 return nuevosProductos
@@ -119,7 +121,9 @@ class GestorProductos {
                 var nuevosProductos = []
                 respuesta.forEach(prod => {
                     var nuevoProducto = new Producto(prod.id, prod.nombre, prod.foto, (prod.destacado == 1), prod.categoria.split(","), prod.descripcion, prod.precio)
-                    this.productos.push(nuevoProducto)
+                    if (this.getProductoId(nuevoProducto.id) == undefined){
+                        this.productos.push(nuevoProducto)
+                    }
                     nuevosProductos.push(nuevoProducto)
                 });
                 return nuevosProductos

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -1,7 +1,6 @@
 class GestorProductos {
     constructor() {
         this.productos = []
-        this.productosDestacados = []
         this.categoriasPrincipales = []
         GLOBAL_CACHE_JSONS.getJSON("/api/productos/categorias/").then((categoriasPrincipales) => {
             if (categoriasPrincipales !== null) {
@@ -41,7 +40,9 @@ class GestorProductos {
      * 
      */
     getCategoriasEnCategoriaPrincipal(categoriaPrincipal) {
+        console.log(categoriaPrincipal)
         var categoriaEncontrada = this.categoriasPrincipales.find(categoria => this.filtrarCategoriaPrincipal(categoriaPrincipal, categoria))
+        console.log(categoriaEncontrada)
         if (categoriaEncontrada == undefined) { return undefined }
         if (categoriaEncontrada.categorias.length > 0) {
             return $.when(categoriaEncontrada.categorias[0])
@@ -61,10 +62,7 @@ class GestorProductos {
      * @param {String} categoria Categoria a buscar
      */
     getProductosCategoria(categoriaPrincipal, categoria) {
-        var productosFiltrados = []
-        productosFiltrados = productosFiltrados.concat(
-            this.productosDestacados.filter(producto => this.filtrarCategoria(categoria, producto)),
-            this.productos.filter(producto => this.filtrarCategoria(categoria, producto)))
+        var productosFiltrados = this.productos.filter(producto => this.filtrarCategoria(categoria, producto))
         if (productosFiltrados.length > 0) {
             return $.when(productosFiltrados)
         } else {
@@ -72,11 +70,7 @@ class GestorProductos {
                 var nuevosProductos = []
                 respuesta.forEach(prod => {
                     var nuevoProducto = new Producto(prod.id, prod.nombre, prod.foto, (prod.destacado == 1), prod.categoria.split(","), prod.descripcion, prod.precio)
-                    if (nuevoProducto.destacado) {
-                        this.productosDestacados.push(nuevoProducto)
-                    } else {
-                        this.productos.push(nuevoProducto)
-                    }
+                    this.productos.push(nuevoProducto)
                     nuevosProductos.push(nuevoProducto)
                 });
                 return nuevosProductos
@@ -88,11 +82,7 @@ class GestorProductos {
      * @param {int} id Id a buscar
      */
     getProductoId(id) {
-        var producto = this.productos.find(producto => this.filtrarId(id, producto))
-        if (producto == undefined) {
-            producto = this.productosDestacados.find(producto => this.filtrarId(id, producto))
-        }
-        return producto
+        return this.productos.find(producto => this.filtrarId(id, producto))
     }
 
     getCategoriasPrincipales() {
@@ -121,15 +111,18 @@ class GestorProductos {
     }
 
     getProductosDestacados() {
-        if (this.productosDestacados.length > 0) {
-            return $.when(this.productosDestacados)
+        var productosFiltrados = this.productos.filter(producto => producto.destacado)
+        if (productosFiltrados.length > 0) {
+            return $.when(productosFiltrados)
         } else {
             return GLOBAL_CACHE_JSONS.getJSON("/api/productos?destacados=1").then((respuesta) => {
+                var nuevosProductos = []
                 respuesta.forEach(prod => {
                     var nuevoProducto = new Producto(prod.id, prod.nombre, prod.foto, (prod.destacado == 1), prod.categoria.split(","), prod.descripcion, prod.precio)
-                    this.productosDestacados.push(nuevoProducto)
+                    this.productos.push(nuevoProducto)
+                    nuevosProductos.push(nuevoProducto)
                 });
-                return this.productosDestacados
+                return nuevosProductos
             })
         }
     }

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -1,6 +1,7 @@
 class GestorProductos {
     constructor() {
         this.productos = []
+        this.productosDestacados = []
         this.categoriasPrincipales = []
         GLOBAL_CACHE_JSONS.getJSON("/api/productos/categorias/").then((categoriasPrincipales) => {
             if (categoriasPrincipales !== null) {
@@ -60,7 +61,10 @@ class GestorProductos {
      * @param {String} categoria Categoria a buscar
      */
     getProductosCategoria(categoriaPrincipal, categoria) {
-        var productosFiltrados = this.productos.filter(producto => this.filtrarCategoria(categoria, producto))
+        var productosFiltrados = []
+        productosFiltrados = productosFiltrados.concat(
+            this.productosDestacados.filter(producto => this.filtrarCategoria(categoria, producto)),
+            this.productos.filter(producto => this.filtrarCategoria(categoria, producto)))
         if (productosFiltrados.length > 0) {
             return $.when(productosFiltrados)
         } else {
@@ -68,7 +72,11 @@ class GestorProductos {
                 var nuevosProductos = []
                 respuesta.forEach(prod => {
                     var nuevoProducto = new Producto(prod.id, prod.nombre, prod.foto, (prod.destacado == 1), prod.categoria.split(","), prod.descripcion, prod.precio)
-                    this.productos.push(nuevoProducto)
+                    if (nuevoProducto.destacado) {
+                        this.productosDestacados.push(nuevoProducto)
+                    } else {
+                        this.productos.push(nuevoProducto)
+                    }
                     nuevosProductos.push(nuevoProducto)
                 });
                 return nuevosProductos

--- a/src/cliente/js/core/Gestion Productos/GestorProductos.js
+++ b/src/cliente/js/core/Gestion Productos/GestorProductos.js
@@ -88,7 +88,11 @@ class GestorProductos {
      * @param {int} id Id a buscar
      */
     getProductoId(id) {
-        return this.productos.find(producto => this.filtrarId(id, producto))
+        var producto = this.productos.find(producto => this.filtrarId(id, producto))
+        if (producto == undefined) {
+            producto = this.productosDestacados.find(producto => this.filtrarId(id, producto))
+        }
+        return producto
     }
 
     getCategoriasPrincipales() {
@@ -116,9 +120,9 @@ class GestorProductos {
         });
     }
 
-    getProductosDestacados(){
+    getProductosDestacados() {
         if (this.productosDestacados.length > 0) {
-            return $.when(productosDestacados)
+            return $.when(this.productosDestacados)
         } else {
             return GLOBAL_CACHE_JSONS.getJSON("/api/productos?destacados=1").then((respuesta) => {
                 respuesta.forEach(prod => {

--- a/src/cliente/js/funciones.js
+++ b/src/cliente/js/funciones.js
@@ -43,13 +43,16 @@ function montarMenu(url, vista) {
 
 function redirigir() {
     var url = extraerCookie("Redirect")
+    borrarCookie("Redirect")
     if (url !== null) {
         url = decodeURIComponent(url.split("=")[1])
-        url = url.split("/")[1]
-        cargarVista(url)
-        borrarCookie("Redirect")
-        return true
+        url = url.split("/")[1].toLowerCase()
+        if (GLOBAL_REDIRECCIONES.hasOwnProperty(url)){
+            cargarVista(GLOBAL_REDIRECCIONES[url])
+            return true
     }
+    }
+    return false
 }
 
 function extraerCookie(nombre) {

--- a/src/cliente/js/vistas/principales.js
+++ b/src/cliente/js/vistas/principales.js
@@ -40,19 +40,3 @@ function vista_Portada(puntoMontaje) {
     montarMenu("/api/menu", "portada")
     return $.when($.getScript("libs/slick-1.8.1/slick.min.js")).then(() => { generarCarrusel(".js-carrusel") })
 }
-
-function vista_Ofertas(puntoMontaje) {
-    $.when(montarMenu("/api/menu", "productos")).then(() => { vista_Productos_montarMenu(puntoMontaje, false) });
-    $(puntoMontaje).html("<div class='c-productos js-productos-destacados'></div>")
-    GLOBAL_GESTOR_PRODUCTOS.getProductosDestacados().then((productos) => {
-        productos.forEach(producto => {
-            if (!vista_Productos_existeEnGrid(producto.id)) {
-                $('.js-productos-destacados').append(vista_Productos_generarProducto(producto))
-            }
-        })
-        $(".js-producto-carrito").off('click').on('click', function() {
-            carrito_AñadirArticulo($(this).parent().data('id'));
-        })
-        $(".js-producto-imagen").on('click', vista_Productos_generarModal)
-    })
-}

--- a/src/cliente/js/vistas/principales.js
+++ b/src/cliente/js/vistas/principales.js
@@ -41,3 +41,16 @@ function vista_Portada(puntoMontaje) {
     return $.when($.getScript("libs/slick-1.8.1/slick.min.js")).then(() => { generarCarrusel(".js-carrusel") })
 }
 
+function vista_Ofertas(puntoMontaje) {
+    $.when(montarMenu("/api/menu", "productos")).then(() => { vista_Productos_montarMenu(puntoMontaje, false) });
+    $(puntoMontaje).html("<div class='c-productos js-productos-destacados'></div>")
+    GLOBAL_GESTOR_PRODUCTOS.getProductosDestacados().then((productos) => {
+        productos.forEach(producto => {
+            if (!vista_Productos_existeEnGrid(producto.id)) {
+                $('.js-productos-destacados').append(vista_Productos_generarProducto(producto))
+            }
+        })
+        $(".js-producto-carrito").off('click').on('click', carrito_AñadirArticulo)
+        $(".js-producto-imagen").on('click', vista_Productos_generarModal)
+    })
+}

--- a/src/cliente/js/vistas/principales.js
+++ b/src/cliente/js/vistas/principales.js
@@ -50,7 +50,9 @@ function vista_Ofertas(puntoMontaje) {
                 $('.js-productos-destacados').append(vista_Productos_generarProducto(producto))
             }
         })
-        $(".js-producto-carrito").off('click').on('click', carrito_AñadirArticulo)
+        $(".js-producto-carrito").off('click').on('click', function() {
+            carrito_AñadirArticulo($(this).parent().data('id'));
+        })
         $(".js-producto-imagen").on('click', vista_Productos_generarModal)
     })
 }

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -148,7 +148,7 @@ function vista_Productos_generarProducto(producto) {
             `+ precioEnEuros(producto["precio"]) + `
         </div>
         <div class='c-producto__carrito`
-    if (carrito.getArticulo(producto.id) !== undefined) {
+    if (GLOBAL_CARRITO.getArticulo(producto.id) !== undefined) {
         html += ` c-producto__carrito--en-carrito`
     }
     html += ` js-producto-carrito'>

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -1,4 +1,7 @@
 function vista_Productos(puntoMontaje, categoria) {
+    if ($(puntoMontaje).children().length < 1 || $(puntoMontaje).children(".c-final").length > 0){
+        cargarVista('ofertas'); return false;
+    }
     if (GLOBAL_VISTA_ACTUAL != "productos" && GLOBAL_VISTA_ACTUAL != "ofertas") {
         $.when(montarMenu("/api/menu", "productos")).then(() => { vista_Productos_montarMenu(puntoMontaje, categoria) });
     } else {

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -31,14 +31,18 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
         $(".c-menu__sub").removeClass("c-menu__item--destacado")
         $("[data-id=" + categoria["nombre"] + "]").addClass("c-menu__item--destacado")
         if ($(".l-distribucion__menu--expandido").length < 1) {
-            $(`<div class="l-distribucion__menu--expandido">
-            <div class="c-menu-expandido c-menu-expandido--plegado js-menu-expandido"> 
-            <div class='c-menu-expandido__borde' onclick='vista_Productos_alternarExtendido()'>     
-            <i class='fas fa-angle-right c-menu-expandido__flecha'></i> 
+            $(`
+            <div class="l-distribucion__menu--expandido">
+                <div class="c-menu-expandido c-menu-expandido--plegado js-menu-expandido"> 
+                    <div class='c-menu-expandido__borde' onclick='vista_Productos_alternarExtendido()'> 
+                        <i class='fas fa-angle-right c-menu-expandido__flecha'></i> 
+                    </div>
+                    <p class="c-menu-expandido__titulo">Filtro</p>
+                    <ul class="c-menu-expandido__listado js-menu-expandido__listado">
+                    </ul>
+                </div>
             </div>
-            <ul class="c-menu-expandido__listado js-menu-expandido__listado">
-            </ul>
-            </div></div>`).insertBefore(".l-distribucion__menu")
+        `).insertBefore(".l-distribucion__menu")
         }
         GLOBAL_GESTOR_PRODUCTOS.getCategoriasEnCategoriaPrincipal(categoria["nombre"]).then((cates) => {
             var html = "";

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -1,5 +1,5 @@
 function vista_Productos(puntoMontaje, categoria) {
-    if ($(puntoMontaje).children().length < 1 || $(puntoMontaje).children(".c-final").length > 0){
+    if (($(puntoMontaje).children().length < 1 || $(puntoMontaje).children(".c-final").length > 0) && GLOBAL_VISTA_ACTUAL !== "productos"){
         cargarVista('ofertas'); 
         return false;
     }
@@ -35,6 +35,7 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
     } else {
         if ($(".js-menu-productos__contenedor").length < 1) {
             var contenedorCategoriasPrincipales = "<li class='js-menu-productos__contenedor'><ul>"
+            contenedorCategoriasPrincipales += `<li class="c-menu__item  c-menu__sub c-menu__item--destacado" onclick="cargarVista(&quot;ofertas&quot;)">Ofertas</li>`
             GLOBAL_GESTOR_PRODUCTOS.getCategoriasPrincipales().forEach(cate => {
                 contenedorCategoriasPrincipales += `<li class='c-menu__item c-menu__sub js-menu__productos__` + cate + `' onclick='cargarVista("productos",{"nombre" : "` + cate + `"})'>` + cate + `</li>`
             })
@@ -47,6 +48,17 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
 }
 
 function vista_Productos__montarContenido(puntoMontaje,categoria) {
+    if (categoria == undefined){
+        var clases = $(".c-menu__item--destacado").last().attr('class').split("js-menu__productos__")	
+        var categoria = clases[clases.length - 1].split(" ")[0]	
+        vista_Productos_montarContenidoCategoria(puntoMontaje,categoria)
+            
+    }else{
+        vista_Productos_montarContenidoCategoria(puntoMontaje,categoria)
+   }
+}
+function vista_Productos_montarContenidoCategoria(puntoMontaje,categoria){
+    console.log('cargando',categoria)
     GLOBAL_GESTOR_PRODUCTOS.getCategoriasEnCategoriaPrincipal(categoria).then((cates) => {
         var montados = 0
         $(puntoMontaje).html("");

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -1,6 +1,7 @@
 function vista_Productos(puntoMontaje, categoria) {
     if ($(puntoMontaje).children().length < 1 || $(puntoMontaje).children(".c-final").length > 0){
-        cargarVista('ofertas'); return false;
+        cargarVista('ofertas'); 
+        return false;
     }
     if (GLOBAL_VISTA_ACTUAL != "productos" && GLOBAL_VISTA_ACTUAL != "ofertas") {
         $.when(montarMenu("/api/menu", "productos")).then(() => { vista_Productos_montarMenu(puntoMontaje, categoria) });

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -1,5 +1,5 @@
 function vista_Productos(puntoMontaje, categoria) {
-    if (GLOBAL_VISTA_ACTUAL != "productos") {
+    if (GLOBAL_VISTA_ACTUAL != "productos" && GLOBAL_VISTA_ACTUAL != "ofertas") {
         $.when(montarMenu("/api/menu", "productos")).then(() => { vista_Productos_montarMenu(puntoMontaje, categoria) });
     } else {
         vista_Productos_montarMenu(puntoMontaje, categoria);

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -51,7 +51,7 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
     } else {
         if ($(".js-menu-productos__contenedor").length < 1) {
             var contenedorCategoriasPrincipales = "<li class='js-menu-productos__contenedor'><ul>"
-            contenedorCategoriasPrincipales += `<li class="c-menu__item  c-menu__sub c-menu__item--destacado" onclick="cargarVista(&quot;ofertas&quot;)">Ofertas</li>`
+            contenedorCategoriasPrincipales += `<li class="c-menu__item  c-menu__sub c-menu__item--destacado" onclick="cargarVista('ofertas')">Ofertas</li>`
             GLOBAL_GESTOR_PRODUCTOS.getCategoriasPrincipales().forEach(cate => {
                 contenedorCategoriasPrincipales += `<li class='c-menu__item c-menu__sub js-menu__productos__` + cate + `' onclick='cargarVista("productos",{"nombre" : "` + cate + `"})'>` + cate + `</li>`
             })

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -26,7 +26,7 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
                 html += `<li><input type="checkbox" onclick="vista_Productos__montarContenido('` + puntoMontaje + `')" class="c-menu-expandido__checkbox js-menu-expandido__checkbox__` + cate + `" checked>` + cate + `</li>`
             })
             $(".js-menu-expandido__listado").html(html)
-            vista_Productos__montarContenido(puntoMontaje)
+            vista_Productos__montarContenido(puntoMontaje,categoria["nombre"])
         })
     } else {
         if ($(".js-menu-productos__contenedor").length < 1) {
@@ -42,15 +42,13 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
     }
 }
 
-function vista_Productos__montarContenido(puntoMontaje) {
-    var clases = $(".c-menu__item--destacado").last().attr('class').split("js-menu__productos__")
-    var categoriaSeleccionada = clases[clases.length - 1].split(" ")[0]
-    GLOBAL_GESTOR_PRODUCTOS.getCategoriasEnCategoriaPrincipal(categoriaSeleccionada).then((cates) => {
+function vista_Productos__montarContenido(puntoMontaje,categoria) {
+    GLOBAL_GESTOR_PRODUCTOS.getCategoriasEnCategoriaPrincipal(categoria).then((cates) => {
         var montados = 0
         $(puntoMontaje).html("");
         cates.forEach(cate => {
             if ($('.js-menu-expandido__checkbox__' + cate).is(':checked')) {
-                vista_Productos_cargarDe(puntoMontaje, categoriaSeleccionada, cate)
+                vista_Productos_cargarDe(puntoMontaje, categoria, cate)
                 montados++;
             }
         })

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -1,6 +1,6 @@
 function vista_Productos(puntoMontaje, categoria) {
-    if (($(puntoMontaje).children().length < 1 || $(puntoMontaje).children(".c-final").length > 0) && GLOBAL_VISTA_ACTUAL !== "productos"){
-        cargarVista('ofertas'); 
+    if (($(puntoMontaje).children().length < 1 || $(puntoMontaje).children(".c-final").length > 0) && GLOBAL_VISTA_ACTUAL !== "productos") {
+        cargarVista('ofertas');
         return false;
     }
     if (GLOBAL_VISTA_ACTUAL != "productos" && GLOBAL_VISTA_ACTUAL != "ofertas") {
@@ -19,7 +19,7 @@ function vista_Productos_Ofertas(puntoMontaje) {
                 $('.js-productos-destacados').append(vista_Productos_generarProducto(producto))
             }
         })
-        $(".js-producto-carrito").off('click').on('click', function() {
+        $(".js-producto-carrito").off('click').on('click', function () {
             carrito_AñadirArticulo($(this).parent().data('id'));
         })
         $(".js-producto-imagen").on('click', vista_Productos_generarModal)
@@ -29,7 +29,7 @@ function vista_Productos_Ofertas(puntoMontaje) {
 function vista_Productos_montarMenu(puntoMontaje, categoria) {
     if (categoria.hasOwnProperty("nombre")) {
         $(".c-menu__sub").removeClass("c-menu__item--destacado")
-        $(".js-menu__productos__" + categoria["nombre"]).addClass("c-menu__item--destacado")
+        $("[data-id=" + categoria["nombre"] + "]").addClass("c-menu__item--destacado")
         if ($(".l-distribucion__menu--expandido").length < 1) {
             $(`<div class="l-distribucion__menu--expandido">
             <div class="c-menu-expandido c-menu-expandido--plegado js-menu-expandido"> 
@@ -46,14 +46,14 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
                 html += `<li><input type="checkbox" onclick="vista_Productos__montarContenido('` + puntoMontaje + `')" class="c-menu-expandido__checkbox js-menu-expandido__checkbox__` + cate + `" checked>` + cate + `</li>`
             })
             $(".js-menu-expandido__listado").html(html)
-            vista_Productos__montarContenido(puntoMontaje,categoria["nombre"])
+            vista_Productos__montarContenido(puntoMontaje, categoria["nombre"])
         })
     } else {
         if ($(".js-menu-productos__contenedor").length < 1) {
             var contenedorCategoriasPrincipales = "<li class='js-menu-productos__contenedor'><ul>"
             contenedorCategoriasPrincipales += `<li class="c-menu__item  c-menu__sub c-menu__item--destacado" onclick="cargarVista('ofertas')">Ofertas</li>`
             GLOBAL_GESTOR_PRODUCTOS.getCategoriasPrincipales().forEach(cate => {
-                contenedorCategoriasPrincipales += `<li class='c-menu__item c-menu__sub js-menu__productos__` + cate + `' onclick='cargarVista("productos",{"nombre" : "` + cate + `"})'>` + cate + `</li>`
+                contenedorCategoriasPrincipales += `<li data-id='` + cate + `'class='c-menu__item c-menu__sub' onclick='cargarVista("productos",{"nombre" : "` + cate + `"})'>` + cate + `</li>`
             })
             contenedorCategoriasPrincipales += "</ul></li>"
             $(contenedorCategoriasPrincipales).insertAfter(".js-menu-productos")
@@ -63,17 +63,16 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
     }
 }
 
-function vista_Productos__montarContenido(puntoMontaje,categoria) {
-    if (categoria == undefined){
-        var clases = $(".c-menu__item--destacado").last().attr('class').split("js-menu__productos__")	
-        var categoria = clases[clases.length - 1].split(" ")[0]	
-        vista_Productos_montarContenidoCategoria(puntoMontaje,categoria)
-            
-    }else{
-        vista_Productos_montarContenidoCategoria(puntoMontaje,categoria)
-   }
+function vista_Productos__montarContenido(puntoMontaje, categoria) {
+    if (categoria == undefined) {
+        var categoria = $(".c-menu__item--destacado").last().data('id')
+        vista_Productos_montarContenidoCategoria(puntoMontaje, categoria)
+
+    } else {
+        vista_Productos_montarContenidoCategoria(puntoMontaje, categoria)
+    }
 }
-function vista_Productos_montarContenidoCategoria(puntoMontaje,categoria){
+function vista_Productos_montarContenidoCategoria(puntoMontaje, categoria) {
     GLOBAL_GESTOR_PRODUCTOS.getCategoriasEnCategoriaPrincipal(categoria).then((cates) => {
         var montados = 0
         $(puntoMontaje).html("");
@@ -109,7 +108,7 @@ function vista_Productos_cargarDe(puntoMontaje, categoriaPrincipal, categoria) {
                 }
             }
         })
-        $(".js-producto-carrito").off('click').on('click', function() {
+        $(".js-producto-carrito").off('click').on('click', function () {
             carrito_AñadirArticulo($(this).parent().data('id'));
         })
         $(".js-producto-imagen").on('click', vista_Productos_generarModal)
@@ -145,9 +144,9 @@ function vista_Productos_generarProducto(producto) {
             `+ precioEnEuros(producto["precio"]) + `
         </div>
         <div class='c-producto__carrito`
-        if (carrito.getArticulo(producto.id) !== undefined){
-            html += ` c-producto__carrito--en-carrito`
-        }
+    if (carrito.getArticulo(producto.id) !== undefined) {
+        html += ` c-producto__carrito--en-carrito`
+    }
     html += ` js-producto-carrito'>
             <i class='fas fa-cart-plus'></i>
         </div>

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -33,7 +33,7 @@ function vista_Productos_montarMenu(puntoMontaje, categoria) {
         if ($(".l-distribucion__menu--expandido").length < 1) {
             $(`<div class="l-distribucion__menu--expandido">
             <div class="c-menu-expandido c-menu-expandido--plegado js-menu-expandido"> 
-            <div class='c-menu-expandido__borde' onclick='vista_Productos_alternarExtendido()'> 
+            <div class='c-menu-expandido__borde' onclick='vista_Productos_alternarExtendido()'>     
             <i class='fas fa-angle-right c-menu-expandido__flecha'></i> 
             </div>
             <ul class="c-menu-expandido__listado js-menu-expandido__listado">

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -58,7 +58,6 @@ function vista_Productos__montarContenido(puntoMontaje,categoria) {
    }
 }
 function vista_Productos_montarContenidoCategoria(puntoMontaje,categoria){
-    console.log('cargando',categoria)
     GLOBAL_GESTOR_PRODUCTOS.getCategoriasEnCategoriaPrincipal(categoria).then((cates) => {
         var montados = 0
         $(puntoMontaje).html("");

--- a/src/cliente/js/vistas/productos.js
+++ b/src/cliente/js/vistas/productos.js
@@ -10,6 +10,22 @@ function vista_Productos(puntoMontaje, categoria) {
     }
 }
 
+function vista_Productos_Ofertas(puntoMontaje) {
+    $.when(montarMenu("/api/menu", "productos")).then(() => { vista_Productos_montarMenu(puntoMontaje, false) });
+    $(puntoMontaje).html("<div class='c-productos js-productos-destacados'></div>")
+    GLOBAL_GESTOR_PRODUCTOS.getProductosDestacados().then((productos) => {
+        productos.forEach(producto => {
+            if (!vista_Productos_existeEnGrid(producto.id)) {
+                $('.js-productos-destacados').append(vista_Productos_generarProducto(producto))
+            }
+        })
+        $(".js-producto-carrito").off('click').on('click', function() {
+            carrito_AñadirArticulo($(this).parent().data('id'));
+        })
+        $(".js-producto-imagen").on('click', vista_Productos_generarModal)
+    })
+}
+
 function vista_Productos_montarMenu(puntoMontaje, categoria) {
     if (categoria.hasOwnProperty("nombre")) {
         $(".c-menu__sub").removeClass("c-menu__item--destacado")

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -43,7 +43,7 @@ return [
             "action" => "getCategoria"
         ],
         "API, Productos destacados" => [
-            "route" => "api/productos?destacados=1",
+            "route" => "api/productos?destacado=1",
             "resource" => "productos",
             "action" => "getDestacados"
         ],

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -41,6 +41,11 @@ return [
             "route" => "api/productos/categorias/:categoriaPrincipal/:categoriaEspecifica",
             "resource" => "productos",
             "action" => "getCategoria"
-        ]
+        ],
+        "API, Productos destacados" => [
+            "route" => "api/productos?destacados=1",
+            "resource" => "productos",
+            "action" => "getDestacados"
+        ],
     ]
 ];

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -43,7 +43,7 @@ return [
             "action" => "getCategoria"
         ],
         "API, Productos destacados" => [
-            "route" => "api/productos?destacado=1",
+            "route" => "api/productos?destacado=:destacado",
             "resource" => "productos",
             "action" => "getDestacados"
         ],


### PR DESCRIPTION
Issue #197 
- Apartado ofertas en el menú de productos.
- Ofertas eliminado del menú principal. (Puesto en el sub-menú productos.)
- Si se intenta cargar productos desde una vista vacía (ej: alérgenos), se carga por defecto la sección ofertas.
- /api/productos?destacados=1 devuelve los productos destacados. (No funciona a la inversa.)
- Sistema de redirección vuelve a funcionar, WeekFood.com/productos y WeekFood.com/ofertas redirigen a la vista de productos en la sección ofertas, cualquier otra url redirige a la vista principal.