### PR TITLE
fix(#223): [Grid Productos] Desajustes visuales cuando el titulo es multilinea

### DIFF
--- a/src/cliente/scss/components/_producto.scss
+++ b/src/cliente/scss/components/_producto.scss
@@ -9,10 +9,6 @@
                         'titulo titulo'
                         'precio carrito';
     cursor: pointer;
-   @media only screen and (min-width: $mobile-l) {
-      max-width: 100%;
-      border-radius: 10px;
-   }
 }
 
 .c-producto__imagen {
@@ -41,8 +37,9 @@
     align-self: center;
     margin-right: 5px;
     padding: 14px;
+    align-self: flex-end;
     &--en-carrito {
-        color: green;
+        color: $acento-exito;
     }
 }
 
@@ -51,6 +48,7 @@
     font-size: 30px;
     font-family: $fuente-principal;
     grid-area: precio;
+    align-self: flex-end;
 }
 
 .c-producto__titulo {
@@ -60,4 +58,5 @@
     padding: 10px;
     overflow: hidden;
     text-overflow: ellipsis;
+    align-self: center;
 }


### PR DESCRIPTION
Fixes #223 

He aprovechado para:
- Quitar el media que por lo que he podido ver no hacía nada
- Pasar el color del icono de carrito verde al color exito que tenemos

![image](https://user-images.githubusercontent.com/36030998/52039130-01c92f80-2534-11e9-9f8c-5e3889330f64.png)
