### PR TITLE
feat(#264): [CRUD] [PHP, JS] Servicio & endpoints Productos

### DIFF
--- a/admin/src/app/modal-producto/modal-producto.component.html
+++ b/admin/src/app/modal-producto/modal-producto.component.html
@@ -14,7 +14,7 @@
           <label>Nombre</label>
           <input type="text" [(ngModel)]="productoEditado.nombre" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
           <label>Categoría</label>
-          <input type="text" [(ngModel)]="productoEditado.categoria" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
+          <input type="text" [value]="productoEditado.categoria.join(',')" (input)="productoEditado.categoria = $event.target.value.split(',')" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
           <label>Descripción</label>
           <input type="text" [(ngModel)]="productoEditado.descripcion" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
           <label>Foto</label>

--- a/admin/src/app/modal-producto/modal-producto.component.html
+++ b/admin/src/app/modal-producto/modal-producto.component.html
@@ -14,11 +14,18 @@
           <label>Nombre</label>
           <input type="text" [(ngModel)]="productoEditado.nombre" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
           <label>Categoría</label>
-          <input type="text" [value]="productoEditado.categoria.join(',')" (input)="productoEditado.categoria = $event.target.value.split(',')" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
+          <input 
+            type="text" 
+            [value]="productoEditado.categoria.join(',')" 
+            (input)="productoEditado.categoria = $event.target.value.split(',')" 
+            class="form-control" 
+            [readonly]="modo === 'ver' || modo === 'borrar'"
+            >
           <label>Descripción</label>
           <input type="text" [(ngModel)]="productoEditado.descripcion" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
           <label>Foto</label>
-          <img [src]="productoEditado.foto">
+          <img *ngIf="modo === 'ver' || modo === 'borrar'" [src]="productoEditado.foto">
+          <input *ngIf="modo !== 'ver' && modo !== 'borrar'" [(ngModel)]="productoEditado.foto" class="form-control">
           <label>Destacado</label>
           <input type="checkbox" [(ngModel)]="productoEditado.destacado" [disabled]="modo === 'ver' || modo === 'borrar'">
           <label>Precio</label>

--- a/admin/src/app/modal-producto/modal-producto.component.html
+++ b/admin/src/app/modal-producto/modal-producto.component.html
@@ -20,7 +20,7 @@
             (input)="productoEditado.categoria = $event.target.value.split(',')" 
             class="form-control" 
             [readonly]="modo === 'ver' || modo === 'borrar'"
-            >
+          >
           <label>Descripción</label>
           <input type="text" [(ngModel)]="productoEditado.descripcion" class="form-control" [readonly]="modo === 'ver' || modo === 'borrar'">
           <label>Foto</label>

--- a/admin/src/app/modal-producto/modal-producto.component.html
+++ b/admin/src/app/modal-producto/modal-producto.component.html
@@ -26,7 +26,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <button *ngIf="modo === 'editar'" type="button" class="btn btn-success" (click)="guardar()">Guardar</button>
+        <button *ngIf="modo === 'editar'" type="button" class="btn btn-success" (click)="editar()">Guardar</button>
         <button *ngIf="modo === 'crear'" type="button" class="btn btn-success" (click)="crear()">Crear</button>
         <button *ngIf="modo === 'borrar'" type="button" class="btn btn-danger" (click)="borrar()">Borrar</button>
         <button *ngIf="modo === 'ver'" type="button" class="btn btn-secondary" (click)="cerrarse()">Cerrar</button>

--- a/admin/src/app/modal-producto/modal-producto.component.scss
+++ b/admin/src/app/modal-producto/modal-producto.component.scss
@@ -1,7 +1,7 @@
 .c-modal-producto {
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-auto-rows: 1fr;
+    grid-auto-rows: auto;
     grid-gap: 1rem;
     align-items: center;
 }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -44,13 +44,13 @@ export class ModalProductoComponent implements OnInit {
     }
   }
 
-  guardar() {
+  editar() {
     this.productosService.editarProducto(this.productoEditado)
       .then(res => {
         this.cerrarse(true);
       })
       .catch((xhr: any, status, err) => {
-        console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
+        console.error('TCL: ModalProductoComponent -> editar -> xhr', xhr.responseJSON);
       })
   }
 
@@ -70,7 +70,7 @@ export class ModalProductoComponent implements OnInit {
         this.cerrarse(true);
       })
       .catch((xhr: any, status, err) => {
-        console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
+        console.error('TCL: ModalProductoComponent -> borrar -> xhr', xhr.responseJSON);
       })
   }
 }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -46,25 +46,21 @@ export class ModalProductoComponent implements OnInit {
 
   guardar() {
     // TODO: enlazar con service
-    $('.js-modal-producto').modal('hide').one('hidden.bs.modal', () => {
-      // destuir modal solo cuando se haya ocultado visualmente
-      this.cerrado.emit();
-    });
+    this.cerrarse();
   }
 
   crear() {
-    // TODO: enlazar con service
-    $('.js-modal-producto').modal('hide').one('hidden.bs.modal', () => {
-      // destuir modal solo cuando se haya ocultado visualmente
-      this.cerrado.emit();
-    });
+    this.productosService.crearProducto(this.productoEditado)
+    .then(res => {
+      this.cerrarse();
+    })
+    .catch((xhr:any, status, err) => {
+			console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
+    })
   }
 
   borrar() {
     // TODO: enlazar con service
-    $('.js-modal-producto').modal('hide').one('hidden.bs.modal', () => {
-      // destuir modal solo cuando se haya ocultado visualmente
-      this.cerrado.emit();
-    });
+    this.cerrarse();
   }
 }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -16,7 +16,7 @@ export class ModalProductoComponent implements OnInit {
 
   productoEditado: Producto;
 
-  constructor(private productosService: ProductosService) {}
+  constructor(private productosService: ProductosService) { }
 
   ngOnInit() {
     $('.js-modal-producto').modal('show');
@@ -49,19 +49,23 @@ export class ModalProductoComponent implements OnInit {
       .then(res => {
         this.cerrarse(true);
       })
-      .catch((xhr: any, status, err) => {
-        console.error('TCL: ModalProductoComponent -> editar -> xhr', xhr.responseJSON);
+      .catch((xhr: any) => {
+        console.error('Error AJAX al editar Producto');
+        console.log('Producto:', this.productoEditado);
+        console.log('XHR:', xhr);
       })
   }
 
   crear() {
     this.productosService.crearProducto(this.productoEditado)
-    .then(res => {
-      this.cerrarse(true);
-    })
-    .catch((xhr:any, status, err) => {
-			console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
-    })
+      .then(res => {
+        this.cerrarse(true);
+      })
+      .catch((xhr: any) => {
+        console.error('Error AJAX al crear Producto');
+        console.log('Producto:', this.productoEditado);
+        console.log('XHR:', xhr);
+      })
   }
 
   borrar() {
@@ -69,8 +73,10 @@ export class ModalProductoComponent implements OnInit {
       .then(res => {
         this.cerrarse(true);
       })
-      .catch((xhr: any, status, err) => {
-        console.error('TCL: ModalProductoComponent -> borrar -> xhr', xhr.responseJSON);
+      .catch((xhr: any) => {
+        console.error('Error AJAX al borrar Producto');
+        console.log('Producto:', this.productoEditado);
+        console.log('XHR:', xhr);
       })
   }
 }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -45,8 +45,13 @@ export class ModalProductoComponent implements OnInit {
   }
 
   guardar() {
-    // TODO: enlazar con service
-    this.cerrarse();
+    this.productosService.editarProducto(this.productoEditado)
+      .then(res => {
+        this.cerrarse();
+      })
+      .catch((xhr: any, status, err) => {
+        console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
+      })
   }
 
   crear() {

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -12,7 +12,7 @@ export class ModalProductoComponent implements OnInit {
   @Input() producto: Producto;
   @Input() modo: string;
 
-  @Output() cerrado = new EventEmitter();
+  @Output() cerrado = new EventEmitter<boolean>();
 
   productoEditado: Producto;
 
@@ -24,10 +24,10 @@ export class ModalProductoComponent implements OnInit {
     this.productoEditado = Object.assign({}, this.producto);
   }
 
-  cerrarse() {
+  cerrarse(actualizarVista: boolean = false) {
     $('.js-modal-producto').modal('hide').one('hidden.bs.modal', () => {
       // destuir modal solo cuando se haya ocultado visualmente
-      this.cerrado.emit();
+      this.cerrado.emit(actualizarVista);
     });
   }
 
@@ -47,7 +47,7 @@ export class ModalProductoComponent implements OnInit {
   guardar() {
     this.productosService.editarProducto(this.productoEditado)
       .then(res => {
-        this.cerrarse();
+        this.cerrarse(true);
       })
       .catch((xhr: any, status, err) => {
         console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
@@ -57,7 +57,7 @@ export class ModalProductoComponent implements OnInit {
   crear() {
     this.productosService.crearProducto(this.productoEditado)
     .then(res => {
-      this.cerrarse();
+      this.cerrarse(true);
     })
     .catch((xhr:any, status, err) => {
 			console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
@@ -66,6 +66,6 @@ export class ModalProductoComponent implements OnInit {
 
   borrar() {
     // TODO: enlazar con service
-    this.cerrarse();
+    this.cerrarse(true);
   }
 }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { Producto } from '../models/Producto';
+import { ProductosService } from '../services/productos.service';
 
 @Component({
   selector: 'app-modal-producto',
@@ -12,13 +13,10 @@ export class ModalProductoComponent implements OnInit {
   @Input() modo: string;
 
   @Output() cerrado = new EventEmitter();
-  @Output() guardado = new EventEmitter();
-  @Output() creado = new EventEmitter();
-  @Output() borrado = new EventEmitter();
 
   productoEditado: Producto;
 
-  constructor() { }
+  constructor(private productosService: ProductosService) {}
 
   ngOnInit() {
     $('.js-modal-producto').modal('show');
@@ -47,26 +45,26 @@ export class ModalProductoComponent implements OnInit {
   }
 
   guardar() {
-    // TODO: validacion
+    // TODO: enlazar con service
     $('.js-modal-producto').modal('hide').one('hidden.bs.modal', () => {
       // destuir modal solo cuando se haya ocultado visualmente
-      this.guardado.emit(this.productoEditado);
+      this.cerrado.emit();
     });
   }
 
   crear() {
-    // TODO: validacion
+    // TODO: enlazar con service
     $('.js-modal-producto').modal('hide').one('hidden.bs.modal', () => {
       // destuir modal solo cuando se haya ocultado visualmente
-      this.creado.emit(this.productoEditado);
+      this.cerrado.emit();
     });
   }
 
   borrar() {
-    // TODO: validacion
+    // TODO: enlazar con service
     $('.js-modal-producto').modal('hide').one('hidden.bs.modal', () => {
       // destuir modal solo cuando se haya ocultado visualmente
-      this.borrado.emit(this.productoEditado);
+      this.cerrado.emit();
     });
   }
 }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -31,14 +31,14 @@ export class ModalProductoComponent implements OnInit {
     });
   }
 
-  cerrarseOverlay(evento) {
+  cerrarseOverlay(evento: MouseEvent) {
     // solo cerrar si se ha hecho click en el overlay, no en el modal como tal
     if (evento.target === document.querySelector('.modal')) {
       this.cerrarse();
     }
   }
 
-  cerrarseEsc(evento) {
+  cerrarseEsc(evento: KeyboardEvent) {
     if (evento.key === 'Escape') {
       this.cerrarse();
     }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -34,7 +34,7 @@ export class ModalProductoComponent implements OnInit {
   }
 
   cerrarseOverlay(evento) {
-    // solo cerrar si se ha hecho click en el overlay, no el el modal como tal
+    // solo cerrar si se ha hecho click en el overlay, no en el modal como tal
     if (evento.target === document.querySelector('.modal')) {
       this.cerrarse();
     }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -53,7 +53,7 @@ export class ModalProductoComponent implements OnInit {
         console.error('Error AJAX al editar Producto');
         console.log('Producto:', this.productoEditado);
         console.log('XHR:', xhr);
-      })
+      });
   }
 
   crear() {
@@ -65,7 +65,7 @@ export class ModalProductoComponent implements OnInit {
         console.error('Error AJAX al crear Producto');
         console.log('Producto:', this.productoEditado);
         console.log('XHR:', xhr);
-      })
+      });
   }
 
   borrar() {
@@ -77,6 +77,6 @@ export class ModalProductoComponent implements OnInit {
         console.error('Error AJAX al borrar Producto');
         console.log('Producto:', this.productoEditado);
         console.log('XHR:', xhr);
-      })
+      });
   }
 }

--- a/admin/src/app/modal-producto/modal-producto.component.ts
+++ b/admin/src/app/modal-producto/modal-producto.component.ts
@@ -65,7 +65,12 @@ export class ModalProductoComponent implements OnInit {
   }
 
   borrar() {
-    // TODO: enlazar con service
-    this.cerrarse(true);
+    this.productosService.borrarProducto(this.productoEditado)
+      .then(res => {
+        this.cerrarse(true);
+      })
+      .catch((xhr: any, status, err) => {
+        console.error('TCL: ModalProductoComponent -> crear -> xhr', xhr.responseJSON);
+      })
   }
 }

--- a/admin/src/app/services/productos.service.ts
+++ b/admin/src/app/services/productos.service.ts
@@ -53,4 +53,16 @@ export class ProductosService {
       }
     });
   }
+
+  borrarProducto(producto: Producto) {    
+    return $.ajax({
+      type: 'DELETE',
+      url: `${ProductosService.API_PRODUCTOS}/${producto.id}`,
+      contentType: 'application/json',
+      data: JSON.stringify(producto),
+      xhrFields: {
+        withCredentials: true
+      }
+    });
+  }
 }

--- a/admin/src/app/services/productos.service.ts
+++ b/admin/src/app/services/productos.service.ts
@@ -27,4 +27,18 @@ export class ProductosService {
       });
     });
   }
+
+  crearProducto(producto: Producto) {
+    delete producto.id;
+
+    return $.ajax({
+      type: 'POST',
+      url: ProductosService.API_PRODUCTOS,
+      contentType: 'application/json',
+      data: producto,
+      xhrFields: {
+        withCredentials: true
+      }
+    });
+  }
 }

--- a/admin/src/app/services/productos.service.ts
+++ b/admin/src/app/services/productos.service.ts
@@ -35,7 +35,7 @@ export class ProductosService {
       type: 'POST',
       url: ProductosService.API_PRODUCTOS,
       contentType: 'application/json',
-      data: producto,
+      data: JSON.stringify(producto),
       xhrFields: {
         withCredentials: true
       }

--- a/admin/src/app/services/productos.service.ts
+++ b/admin/src/app/services/productos.service.ts
@@ -41,4 +41,16 @@ export class ProductosService {
       }
     });
   }
+
+  editarProducto(producto: Producto) {
+    return $.ajax({
+      type: 'PUT',
+      url: `${ProductosService.API_PRODUCTOS}/${producto.id}`,
+      contentType: 'application/json',
+      data: JSON.stringify(producto),
+      xhrFields: {
+        withCredentials: true
+      }
+    });
+  }
 }

--- a/admin/src/app/views/productos/productos.component.html
+++ b/admin/src/app/views/productos/productos.component.html
@@ -38,5 +38,5 @@
   *ngIf="modalAbierto"
   [producto]="productoActual"
   [modo]="modoModal"
-  (cerrado)="destruirModal()"
+  (cerrado)="alCerrarseModal($event)"
 ></app-modal-producto>

--- a/admin/src/app/views/productos/productos.component.html
+++ b/admin/src/app/views/productos/productos.component.html
@@ -19,7 +19,7 @@
           <td>{{ producto.id }}</td>
           <td>{{ producto.nombre }}</td>
           <td>
-            <span *ngFor="let categoria of producto.categoria" class="badge badge-secondary">{{ categoria }}</span>
+            <span *ngFor="let categoria of producto.categoria" class="c-productos__categoria badge badge-secondary">{{ categoria }}</span>
           </td>
           <td>{{ producto.descripcion }}</td>
           <td><img [src]="producto.foto"></td>

--- a/admin/src/app/views/productos/productos.component.html
+++ b/admin/src/app/views/productos/productos.component.html
@@ -39,7 +39,4 @@
   [producto]="productoActual"
   [modo]="modoModal"
   (cerrado)="destruirModal()"
-  (guardado)="editarProducto($event)"
-  (creado)="crearProducto($event)"
-  (borrado)="borrarProducto($event)"
 ></app-modal-producto>

--- a/admin/src/app/views/productos/productos.component.scss
+++ b/admin/src/app/views/productos/productos.component.scss
@@ -6,6 +6,10 @@
     text-align: center;
 }
 
+.c-productos__categoria {
+    margin: 0 2px;
+}
+
 input[type="checkbox"] {
     width: 1.25rem;
     height: 1.25rem;

--- a/admin/src/app/views/productos/productos.component.ts
+++ b/admin/src/app/views/productos/productos.component.ts
@@ -16,13 +16,17 @@ export class ProductosComponent implements OnInit {
   modalAbierto: boolean = false;
   modoModal: string = '';
 
-  constructor(private productosService: ProductosService) {}
-  
+  constructor(private productosService: ProductosService) { }
+
   ngOnInit() {
+    this.getProductos();
+  }
+
+  getProductos() {
     this.productosService.getProductos()
       .then((productos: Producto[]) => {
         this.productos = productos;
-      })
+      });
   }
 
   abrirModalVer(producto: Producto) {
@@ -53,10 +57,14 @@ export class ProductosComponent implements OnInit {
     this.productoActual = producto;
   }
 
-  destruirModal() {
+  alCerrarseModal(actualizarse: boolean) {
     this.modalAbierto = false;
     this.modoModal = '';
 
     this.productoActual = null;
+
+    if (actualizarse) {
+      this.getProductos();
+    }
   }
 }

--- a/admin/src/app/views/productos/productos.component.ts
+++ b/admin/src/app/views/productos/productos.component.ts
@@ -69,7 +69,10 @@ export class ProductosComponent implements OnInit {
   crearProducto(productoCreado) {
     console.log('recibido producto creado', productoCreado);
     // TODO: mandar a ProductosService
-    this.destruirModal();
+    this.productosService.crearProducto(productoCreado).then((productoCreado) => {
+			console.log('TCL: ProductosComponent -> crearProducto -> productoCreado', productoCreado);
+      this.destruirModal();
+    });
   }
 
   borrarProducto(productoBorrado) {

--- a/admin/src/app/views/productos/productos.component.ts
+++ b/admin/src/app/views/productos/productos.component.ts
@@ -59,25 +59,4 @@ export class ProductosComponent implements OnInit {
 
     this.productoActual = null;
   }
-
-  editarProducto(productoEditado) {
-    console.log('recibido producto editado', productoEditado);
-    // TODO: mandar a ProductosService
-    this.destruirModal();
-  }
-
-  crearProducto(productoCreado) {
-    console.log('recibido producto creado', productoCreado);
-    // TODO: mandar a ProductosService
-    this.productosService.crearProducto(productoCreado).then((productoCreado) => {
-			console.log('TCL: ProductosComponent -> crearProducto -> productoCreado', productoCreado);
-      this.destruirModal();
-    });
-  }
-
-  borrarProducto(productoBorrado) {
-    console.log('recibido producto borrado', productoBorrado);
-    // TODO: mandar a ProductosService
-    this.destruirModal();
-  }
 }

--- a/admin/src/styles.scss
+++ b/admin/src/styles.scss
@@ -8,3 +8,14 @@ html, body {
 .table td, .table th {
     padding: 0.5rem;
 }
+
+// Override global: ocultar flechas de input number -- https://stackoverflow.com/a/4298216/3499595
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+input[type=number] {
+    -moz-appearance:textfield;
+}

--- a/admin/src/styles.scss
+++ b/admin/src/styles.scss
@@ -17,5 +17,5 @@ input::-webkit-inner-spin-button {
 }
 
 input[type=number] {
-    -moz-appearance:textfield;
+    -moz-appearance: textfield;
 }

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -40,6 +40,34 @@ class ProductosResource extends Resource {
         $this->setData();
     }
 
+    public function putProductoAction() {
+        $json = file_get_contents('php://input');
+        $producto = json_decode($json, true);
+
+        // preparar categoria para la BD
+        $producto['categoria'] = implode(',', $producto['categoria']);
+        // hay que castear el boolean manualmente
+        $producto['destacado'] = (int) $producto['destacado'];
+
+        $this->sql = 'UPDATE productos
+                      SET
+                        nombre = :nombre,
+                        categoria = :categoria,
+                        descripcion = :descripcion,
+                        foto = :foto,
+                        destacado = :destacado,
+                        precio = :precio
+                      WHERE id = :id';
+        $this->execSQL($producto);
+
+        $this->sql = 'SELECT * FROM productos WHERE id = :id';
+        $this->execSQL([
+            "id" => $producto['id']
+        ]);
+
+        $this->setData();
+    }
+
     public function getCategoriasPrincipalesAction() {
         $this->sql = 'SELECT nombre FROM categoriasprincipales';
         $this->execSQL();

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -21,10 +21,7 @@ class ProductosResource extends Resource {
 
         // preparar categoria para la BD
         $producto['categoria'] = implode(',', $producto['categoria']);
-
-        // el id es null ya que el CRUD no se lo asigna, sino que es asignado al hacer INSERT
-        unset($producto['id']);
-
+        
         $this->sql = 'INSERT INTO productos 
                         (nombre, categoria, descripcion, foto, destacado, precio) 
                      VALUES

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -15,6 +15,25 @@ class ProductosResource extends Resource {
         $this->setData();
     }
 
+    public function postProductoAction() {
+        $json = file_get_contents('php://input');
+        $producto = json_decode($json, true);
+
+        // preparar categoria para la BD
+        $producto['categoria'] = implode(',', $producto['categoria']);
+
+        // el id es null ya que el CRUD no se lo asigna, sino que es asignado al hacer INSERT
+        unset($producto['id']);
+
+        $this->sql = 'INSERT INTO productos 
+                        (nombre, categoria, descripcion, foto, destacado, precio) 
+                     VALUES
+                        (:nombre, :categoria, :descripcion, :foto, :destacado, :precio)';
+        
+        $this->execSQL($producto);
+        $this->setData();
+    }
+
     public function getCategoriasPrincipalesAction() {
         $this->sql = 'SELECT nombre FROM categoriasprincipales';
         $this->execSQL();

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -21,7 +21,7 @@ class ProductosResource extends Resource {
 
         // preparar categoria para la BD
         $producto['categoria'] = implode(',', $producto['categoria']);
-        // hay que castear el boolean manualmente
+        // hay que castear a boolean manualmente
         $producto['destacado'] = (int) $producto['destacado'];
 
         $this->sql = 'INSERT INTO productos 
@@ -49,7 +49,7 @@ class ProductosResource extends Resource {
 
         // preparar categoria para la BD
         $producto['categoria'] = implode(',', $producto['categoria']);
-        // hay que castear el boolean manualmente
+        // hay que castear a boolean manualmente
         $producto['destacado'] = (int) $producto['destacado'];
 
         $this->sql = 'UPDATE productos

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -21,8 +21,8 @@ class ProductosResource extends Resource {
 
         // preparar categoria para la BD
         $producto['categoria'] = implode(',', $producto['categoria']);
-
-        var_dump($producto);
+        // hay que castear el boolean manualmente
+        $producto['destacado'] = (int) $producto['destacado'];
 
         $this->sql = 'INSERT INTO productos 
                         (nombre, categoria, descripcion, foto, destacado, precio) 
@@ -30,6 +30,13 @@ class ProductosResource extends Resource {
                         (:nombre, :categoria, :descripcion, :foto, :destacado, :precio)';
         
         $this->execSQL($producto);
+        $idNuevoProducto = $this->data;
+
+        $this->sql = 'SELECT * FROM productos WHERE id = :id';
+        $this->execSQL([
+            "id" => $idNuevoProducto
+        ]);
+
         $this->setData();
     }
 

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -21,7 +21,9 @@ class ProductosResource extends Resource {
 
         // preparar categoria para la BD
         $producto['categoria'] = implode(',', $producto['categoria']);
-        
+
+        var_dump($producto);
+
         $this->sql = 'INSERT INTO productos 
                         (nombre, categoria, descripcion, foto, destacado, precio) 
                      VALUES

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -37,12 +37,15 @@ class ProductosResource extends Resource {
             "id" => $idNuevoProducto
         ]);
 
+        http_response_code(201);
         $this->setData();
     }
 
     public function putProductoAction() {
         $json = file_get_contents('php://input');
         $producto = json_decode($json, true);
+
+        $id = $this->controller->getParam('id');
 
         // preparar categoria para la BD
         $producto['categoria'] = implode(',', $producto['categoria']);
@@ -58,11 +61,20 @@ class ProductosResource extends Resource {
                         destacado = :destacado,
                         precio = :precio
                       WHERE id = :id';
-        $this->execSQL($producto);
+                      
+        $this->execSQL([
+            "nombre" => $producto['nombre'],
+            "categoria" => $producto['categoria'],
+            "descripcion" => $producto['descripcion'],
+            "foto" => $producto['foto'],
+            "destacado" => $producto['destacado'],
+            "precio" => $producto['precio'],
+            "id" => $id
+        ]);
 
         $this->sql = 'SELECT * FROM productos WHERE id = :id';
         $this->execSQL([
-            "id" => $producto['id']
+            "id" => $id
         ]);
 
         $this->setData();

--- a/src/app/resources/ProductosResource.php
+++ b/src/app/resources/ProductosResource.php
@@ -61,7 +61,7 @@ class ProductosResource extends Resource {
                         destacado = :destacado,
                         precio = :precio
                       WHERE id = :id';
-                      
+
         $this->execSQL([
             "nombre" => $producto['nombre'],
             "categoria" => $producto['categoria'],
@@ -78,6 +78,17 @@ class ProductosResource extends Resource {
         ]);
 
         $this->setData();
+    }
+
+    public function deleteProductoAction() {
+        $id = $this->controller->getParam('id');
+
+        $this->sql = 'DELETE FROM productos WHERE id = :id';
+        $this->execSQL([
+            'id' => $id
+        ]);
+
+        http_response_code(204);
     }
 
     public function getCategoriasPrincipalesAction() {

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -123,5 +123,10 @@ return [
         ]
     ],
     "delete" => [
+        "CRUD, Productos, borrar" => [
+            "route" => "api/productos/:id",
+            "resource" => "productos",
+            "action" => "deleteProducto"
+        ]
     ]
 ];

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -103,6 +103,11 @@ return [
             "route" => "api/auth/usuario_ya_existe",
             "resource" => "auth",
             "action" => "postUsuarioYaExiste"
+        ],
+        "CRUD, Productos, nuevo" => [
+            "route" => "api/productos",
+            "resource" => "productos",
+            "action" => "postProducto"
         ]
     ],
     "put" => [

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -115,6 +115,11 @@ return [
             "route" => "api/carritos/:id",
             "resource" => "carritos",
             "action" => "putCarrito"
+        ],
+        "CRUD, Productos, editar" => [
+            "route" => "api/productos/:id",
+            "resource" => "productos",
+            "action" => "putProducto"
         ]
     ],
     "delete" => [

--- a/src/core/MVC/Resource.php
+++ b/src/core/MVC/Resource.php
@@ -32,6 +32,8 @@ abstract class Resource {
         switch (substr($this->sql, 0, 6)) {
         case "SELECT":
             $i = 0;
+            // limpiar data de queries anteriores
+            $this->data = [];
             foreach ($ps->fetchAll(\PDO::FETCH_ASSOC) as $row) {
                 foreach ($row as $key => $value) {
                     $this->data[$i][$key] = $value;

--- a/src/index.php
+++ b/src/index.php
@@ -10,11 +10,12 @@ header('Access-Control-Allow-Origin: http://localhost:4200');
 header('Access-Control-Allow-Methods: *');
 // CORS: permitir cookies
 header('Access-Control-Allow-Credentials: true');
-// CORS: permitir headers aparte de las permitidas de normal
-header('Access-Control-Allow-Headers: *');
 
 // CORS: devolver 200 (y no seguir con el enrutamiento) para peticiones OPTIONS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    // CORS: permitir cualquier header solicitado por OPTIONS -- https://stackoverflow.com/questions/13146892/cors-access-control-allow-headers-wildcard-being-ignored#comment21412367_13147554
+    header('Access-Control-Allow-Headers: ' . getallheaders()['Access-Control-Request-Headers']);
+
     http_response_code(200);
     exit();
 }

--- a/src/index.php
+++ b/src/index.php
@@ -6,16 +6,17 @@ $config = require_once "./configs/config.php";
 // CORS: permitir acceso desde otros dominios
 // no sirve la wildcard si se manejan cookies, tiene que ser explicito
 header('Access-Control-Allow-Origin: http://localhost:4200');
-// CORS: permitir más métodos aparte de los permitidos en "simple request"
-header('Access-Control-Allow-Methods: *');
 // CORS: permitir cookies
 header('Access-Control-Allow-Credentials: true');
 
-// CORS: devolver 200 (y no seguir con el enrutamiento) para peticiones OPTIONS
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     // CORS: permitir cualquier header solicitado por OPTIONS -- https://stackoverflow.com/questions/13146892/cors-access-control-allow-headers-wildcard-being-ignored#comment21412367_13147554
     header('Access-Control-Allow-Headers: ' . getallheaders()['Access-Control-Request-Headers']);
-
+    
+    // CORS: permitir cualquier método solicitado por OPTIONS
+    header('Access-Control-Allow-Methods: '. getallheaders()['Access-Control-Request-Method']);
+    
+    // CORS: devolver 200 (y no seguir con el enrutamiento) para peticiones OPTIONS
     http_response_code(200);
     exit();
 }


### PR DESCRIPTION
Closes #264 

- **Arquitectura:** será el modal el que se encargará de usar el service, en vez de delegarlo a la view. Esto ahorra problemas como que no se haya guardado bien el producto, pero el modal ya se ha cerrado. También para futuras validaciones de campos. 
  - Ahora el unico evento que manda es que se ha cerrado (y con un booleano para informar a la view si tiene que actualizarse, por si se ha creado un nuevo producto, por ejemplo). 
- **Modal:** si falla el AJAX de momento solo se hace un console log, ya veremos como informaremos al usuario de eso, si con una notificación, si sobreescribiendo el modal, un overlay en el modal...
- **Resource.php:** encontré un bug -- si se hacía un INSERT y luego un SELECT el `data` se quedaba con el lastInsertId, y al no ser un array daba problemas a la hora de ser rellenado con los datos del select.
- **index.php**: Algunos fixes para el CORS, que al parecer la wildcard es relativamente nueva y no todos los navegadores lo han implementado.
- **Modal:** falta validación de campos, pero eso ya hará en otro issue dedicado a hacer el modal productos decente: con un selector de fotos (incluso con subida?), con un campo precio mas intuitivo (mostrar en euros y poner la coma automáticamente), con las categorías como badges y con la posibilidad de añadir nuevas. De momento lo importante es que sea funcional.