### PR TITLE
feat(#270): [Seguridad] [PHP] Escapar valores devueltos desde la BD

### DIFF
--- a/src/core/MVC/Resource.php
+++ b/src/core/MVC/Resource.php
@@ -34,7 +34,7 @@ abstract class Resource {
             $i = 0;
             foreach ($ps->fetchAll(\PDO::FETCH_ASSOC) as $row) {
                 foreach ($row as $key => $value) {
-                    $this->data[$i][$key] = $value;
+                    $this->data[$i][$key] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
                 }
                 $i++;
             }


### PR DESCRIPTION
Closes #270 

![image](https://user-images.githubusercontent.com/36030998/52652634-cf81df80-2eee-11e9-9760-3ad3c7b084f6.png)


Se ve raro en el CRUD eso si, imagino que porque Angular ya escapa cosas:

![image](https://user-images.githubusercontent.com/36030998/52652602-bd07a600-2eee-11e9-9975-d043530d21d3.png)


---

https://stackoverflow.com/questions/1996122/how-to-prevent-xss-with-html-php