### PR TITLE
feat(#276) : AuthGuard en API

### DIFF
--- a/src/app/resources/AuthResource.php
+++ b/src/app/resources/AuthResource.php
@@ -119,4 +119,12 @@ class AuthResource extends Resource {
 
         $this->setData();
     }
+
+    public function getNivelPrivilegioDelUsuario($idUsuario){
+        return $this->auth->getPrivilegeLevel($idUsuario);
+    }
+
+    public function authGuardRechazadoAction() {
+          $this->setError(401, 'AUTH_GUARD_RECHAZADO');   
+    }
 }

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -90,13 +90,13 @@ return [
             "route" => "api/auth/renovar_login",
             "resource" => "auth",
             "action" => "getRenovarLogin",
-            "nivelAuthGuard" => 0
+            "nivelAuthGuard" => -1
         ],
         "API, Auth, logout" => [
             "route" => "api/auth/logout",
             "resource" => "auth",
             "action" => "getLogout",
-            "nivelAuthGuard" => 0
+            "nivelAuthGuard" => -1
         ]
     ],
     "post" => [
@@ -104,7 +104,7 @@ return [
             "route" => "api/carritos",
             "resource" => "carritos",
             "action" => "postCarrito",
-            "nivelAuthGuard" => 0
+            "nivelAuthGuard" => -1
         ],
         "API, Auth, registro" => [
             "route" => "api/auth/registro",

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -12,7 +12,7 @@ return [
             "route" => "/admin",
             "resource" => "admin",
             "action" => "index",
-            "nivelAuthGuard" => -1
+            "nivelAuthGuard" => 9
         ],
         "API" => [
             "route" => "api",
@@ -36,7 +36,7 @@ return [
             "route" => "api/productos",
             "resource" => "productos",
             "action" => "getTodos",
-            "nivelAuthGuard" => -1
+            "nivelAuthGuard" => 9
         ],
         "API, productos, query todas categorias principales" => [
             "route" => "api/productos/categorias",
@@ -96,7 +96,7 @@ return [
             "route" => "api/auth/logout",
             "resource" => "auth",
             "action" => "getLogout",
-            "nivelAuthGuard" => -1
+            "nivelAuthGuard" => 0
         ]
     ],
     "post" => [
@@ -104,7 +104,7 @@ return [
             "route" => "api/carritos",
             "resource" => "carritos",
             "action" => "postCarrito",
-            "nivelAuthGuard" => -1
+            "nivelAuthGuard" => 0
         ],
         "API, Auth, registro" => [
             "route" => "api/auth/registro",

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -36,7 +36,7 @@ return [
             "route" => "api/productos",
             "resource" => "productos",
             "action" => "getTodos",
-            "nivelAuthGuard" => 9
+            "nivelAuthGuard" => -1
         ],
         "API, productos, query todas categorias principales" => [
             "route" => "api/productos/categorias",

--- a/src/configs/routes.php
+++ b/src/configs/routes.php
@@ -5,133 +5,158 @@ return [
         "/" => [
             "route" => "/",
             "resource" => "cliente",
-            "action" => "index"
+            "action" => "index",
+            "nivelAuthGuard" => -1
         ],
         "Admin" => [
             "route" => "/admin",
             "resource" => "admin",
-            "action" => "index"
+            "action" => "index",
+            "nivelAuthGuard" => -1
         ],
         "API" => [
             "route" => "api",
             "resource" => "api",
-            "action" => "error"
+            "action" => "error",
+            "nivelAuthGuard" => -1
         ],
         "API, carrusel" => [
             "route" => "api/carrusel",
             "resource" => "productos",
-            "action" => "getCarrusel"
+            "action" => "getCarrusel",
+            "nivelAuthGuard" => -1
         ],
         "API, menu" => [
             "route" => "api/menu",
             "resource" => "menu",
-            "action" => "getTodos"
+            "action" => "getTodos",
+            "nivelAuthGuard" => -1
         ],
         "API, productos" => [
             "route" => "api/productos",
             "resource" => "productos",
-            "action" => "getTodos"
+            "action" => "getTodos",
+            "nivelAuthGuard" => -1
         ],
         "API, productos, query todas categorias principales" => [
             "route" => "api/productos/categorias",
             "resource" => "productos",
-            "action" => "getCategoriasPrincipales"
+            "action" => "getCategoriasPrincipales",
+            "nivelAuthGuard" => -1
         ],
         "API, productos, query categorias principales" => [
             "route" => "api/productos/categorias/:nombre/subcategorias",
             "resource" => "productos",
-            "action" => "getCategoriaPrincipal"
+            "action" => "getCategoriaPrincipal",
+            "nivelAuthGuard" => -1
         ],
         "API, productos, query categorias" => [
             "route" => "api/productos?categoria=:categoria",
             "resource" => "productos",
-            "action" => "getCategoria"
+            "action" => "getCategoria",
+            "nivelAuthGuard" => -1
         ],
         "API, productos, categorias" => [
             "route" => "api/productos/categorias/subcategorias",
             "resource" => "productos",
-            "action" => "getCategorias"
+            "action" => "getCategorias",
+            "nivelAuthGuard" => -1
         ],
         "API, Productos destacados" => [
             "route" => "api/productos?destacado=:destacado",
             "resource" => "productos",
-            "action" => "getDestacados"
+            "action" => "getDestacados",
+            "nivelAuthGuard" => -1
         ],
         "API, Productos, por id" => [
             "route" => "api/productos/:id",
             "resource" => "productos",
-            "action" => "getProductoID"
+            "action" => "getProductoID",
+            "nivelAuthGuard" => -1
         ],
         "API, carritos por id usuario" => [
             "route" => "api/carritos?usuario=:idUsuario",
             "resource" => "carritos",
-            "action" => "getCarrito"
+            "action" => "getCarrito",
+            "nivelAuthGuard" => 0
         ],
         "API, datos de usuario" => [
             "route" => "api/usuarios/:idUsuario",
             "resource" => "usuarios",
-            "action" => "getUsuario"
+            "action" => "getUsuario",
+            "nivelAuthGuard" => 0
         ],
         "API, Auth, renovar login" => [
             "route" => "api/auth/renovar_login",
             "resource" => "auth",
-            "action" => "getRenovarLogin"
+            "action" => "getRenovarLogin",
+            "nivelAuthGuard" => 0
         ],
         "API, Auth, logout" => [
             "route" => "api/auth/logout",
             "resource" => "auth",
-            "action" => "getLogout"
+            "action" => "getLogout",
+            "nivelAuthGuard" => 0
         ]
     ],
     "post" => [
         "API, carrito" => [
             "route" => "api/carritos",
             "resource" => "carritos",
-            "action" => "postCarrito"
+            "action" => "postCarrito",
+            "nivelAuthGuard" => 0
         ],
         "API, Auth, registro" => [
             "route" => "api/auth/registro",
             "resource" => "auth",
-            "action" => "postRegistro"
+            "action" => "postRegistro",
+            "nivelAuthGuard" => -1
         ],
         "API, Auth, login" => [
             "route" => "api/auth/login",
             "resource" => "auth",
-            "action" => "postLogin"
+            "action" => "postLogin",
+            "nivelAuthGuard" => -1
         ],
         "API, Auth, usuario ya existe" => [
             "route" => "api/auth/usuario_ya_existe",
             "resource" => "auth",
-            "action" => "postUsuarioYaExiste"
+            "action" => "postUsuarioYaExiste",
+            "nivelAuthGuard" => -1
         ],
         "CRUD, Productos, nuevo" => [
             "route" => "api/productos",
             "resource" => "productos",
-            "action" => "postProducto"
+            "action" => "postProducto",
+            "nivelAuthGuard" => 9
         ]
     ],
     "put" => [
         "API, carrito" => [
             "route" => "api/carritos/:id",
             "resource" => "carritos",
-            "action" => "putCarrito"
+            "action" => "putCarrito",
+            "nivelAuthGuard" => 0
         ],
         "API, actualizar usuario" => [
             "route" => "api/usuarios/:idUsuario",
             "resource" => "usuarios",
-            "action" => "putUsuario"
+            "action" => "putUsuario",
+            "nivelAuthGuard" => 0
         ],
         "CRUD, Productos, editar" => [
             "route" => "api/productos/:id",
             "resource" => "productos",
-            "action" => "putProducto"
+            "action" => "putProducto",
+            "nivelAuthGuard" => 9
         ]
     ],
     "delete" => [
         "CRUD, Productos, borrar" => [
             "route" => "api/productos/:id",
             "resource" => "productos",
-            "action" => "deleteProducto"
+            "action" => "deleteProducto",
+            "nivelAuthGuard" => 9
         ]
     ]
 ];

--- a/src/core/Auth/Auth.php
+++ b/src/core/Auth/Auth.php
@@ -10,6 +10,7 @@ class Auth {
     const ERR_LOGIN_WRONG_PASSWORD = 'ERR_LOGIN_WRONG_PASSWORD';
     const ERR_RENEW_LOGIN_INVALID_SIGNATURE = 'ERR_RENEW_LOGIN_INVALID_SIGNATURE';
     const ERR_LOGOUT_NO_LOGIN = 'ERR_LOGOUT_NO_LOGIN';
+    const ERR_NO_AUTHGUARD = 'ERR_NO_AUTHGUARD';
 
     private const SECRET_KEY = "F4Ev-17IbLRcEkwr2p8NRL62bys5fo6AqJrfWZwd5wBUBqDdDueKZz4VlJiWaD1TOXkmNtrU2gCmhNeZvimikm-3yI293zaufdnSoJ0isJ_i1SDmR8GeWVTVkBIPRewP4yBlb2uHbm1Uxppd0wkFau8iNmm5tqQppG0O5Rij5oojForsrvT8ahB9YYkX3fbM5u0RAW4AHbXqrN62xlN17FuXzZUtknI_W_HSOnnrQH5Rj0ZaT2GzRdR9PyaoXfLEduCq_2NowAxIzznsn-OnTFf7VuSrqmj5z1cvO_qyGM0sDNJiUQjKV-R-FQYK9yBkWsWclncU7CVN8uz44CSQng";
 
@@ -183,6 +184,9 @@ class Auth {
             case (self::ERR_LOGOUT_NO_LOGIN):
                 $errorMessage = 'NO_HAY_LOGIN';
                 break;
+            case (self::ERR_NO_AUTHGUARD):
+                $errorMessage = 'NO_HAY_AUTHGUARD';
+                break;
             default:
         }
 
@@ -194,6 +198,7 @@ class Auth {
             case (self::ERR_NO_TOKEN):
             case (self::ERR_RENEW_LOGIN_INVALID_SIGNATURE):
             case (self::ERR_LOGOUT_NO_LOGIN):
+            case (self::ERR_NO_AUTHGUARD):
                 http_response_code(401);
                 break;
             default:
@@ -211,6 +216,9 @@ class Auth {
     }
 
     public function canAccessProtectedRoute($route) {
+        if(!array_key_exists("nivelAuthGuard",$route)){
+            return null;
+        }
 
         if ($route["nivelAuthGuard"] == -1) {
             return true;
@@ -234,5 +242,9 @@ class Auth {
         }
 
         return false;
+    }
+
+    public function noAuthGuard(){
+        $this->sendError(self::ERR_NO_AUTHGUARD);
     }
 }

--- a/src/core/Auth/Auth.php
+++ b/src/core/Auth/Auth.php
@@ -156,10 +156,10 @@ class Auth {
 
     public function isLoggedIn(): bool {
         return session_status() !== PHP_SESSION_NONE
-        && isset($_SESSION['logueado'])
-        && $_SESSION['logueado']
-        && isset($_SESSION['idUsuario'])
-        && $_SESSION['idUsuario'] > -1;
+                && isset($_SESSION['logueado'])
+                && $_SESSION['logueado']
+                && isset($_SESSION['idUsuario'])
+                && $_SESSION['idUsuario'] > -1;
     }
 
     public function getLoggedId() {
@@ -174,16 +174,16 @@ class Auth {
         $errorMessage;
 
         switch ($errorConst) {
-        case (self::ERR_NO_TOKEN):
-            $errorMessage = 'NO_HAY_TOKEN';
-            break;
-        case (self::ERR_RENEW_LOGIN_INVALID_SIGNATURE):
-            $errorMessage = 'FIRMA_INVALIDA';
-            break;
-        case (self::ERR_LOGOUT_NO_LOGIN):
-            $errorMessage = 'NO_HAY_LOGIN';
-            break;
-        default:
+            case (self::ERR_NO_TOKEN):
+                $errorMessage = 'NO_HAY_TOKEN';
+                break;
+            case (self::ERR_RENEW_LOGIN_INVALID_SIGNATURE):
+                $errorMessage = 'FIRMA_INVALIDA';
+                break;
+            case (self::ERR_LOGOUT_NO_LOGIN):
+                $errorMessage = 'NO_HAY_LOGIN';
+                break;
+            default:
         }
 
         if ($errorMessage) {
@@ -191,13 +191,13 @@ class Auth {
         }
 
         switch ($errorConst) {
-        case (self::ERR_NO_TOKEN):
-        case (self::ERR_RENEW_LOGIN_INVALID_SIGNATURE):
-        case (self::ERR_LOGOUT_NO_LOGIN):
-            http_response_code(401);
-            break;
-        default:
-            http_response_code(500);
+            case (self::ERR_NO_TOKEN):
+            case (self::ERR_RENEW_LOGIN_INVALID_SIGNATURE):
+            case (self::ERR_LOGOUT_NO_LOGIN):
+                http_response_code(401);
+                break;
+            default:
+                http_response_code(500);
         }
     }
 

--- a/src/core/Auth/Auth.php
+++ b/src/core/Auth/Auth.php
@@ -200,4 +200,7 @@ class Auth {
                 http_response_code(500);
         }
     }
+    public function canAccessProtectedRoute(){
+        return false;
+    }
 }

--- a/src/core/MVC/Controller.php
+++ b/src/core/MVC/Controller.php
@@ -45,6 +45,7 @@ class Controller extends Router {
 
     public function run() {
         if (($route = $this->parseUriRouter()) != null) {
+            
             $this->setResourceName($route["resource"]);
             $this->setActionName($route["action"]);
         } else {

--- a/src/core/MVC/Controller.php
+++ b/src/core/MVC/Controller.php
@@ -16,6 +16,7 @@ class Controller extends Router {
 
     public function __construct() {
         $this->globals = core\Globals::getInstance();
+        $this->auth = $this->globals->get('auth');
         $config = $this->globals->get("config");
         $this->resourcePath = $config["site"]["resources"];
         $this->defaultRoutesConfig = $config["site"]["configs"] . "routes.php";
@@ -45,9 +46,13 @@ class Controller extends Router {
 
     public function run() {
         if (($route = $this->parseUriRouter()) != null) {
-            
-            $this->setResourceName($route["resource"]);
-            $this->setActionName($route["action"]);
+            if ($this->auth->canAccessProtectedRoute($route)) {
+                $this->setResourceName($route["resource"]);
+                $this->setActionName($route["action"]);
+            } else {
+                $this->setResourceName("auth");
+                $this->setActionName("authGuardRechazado");
+            }
         } else {
             if (substr($_SERVER["REQUEST_URI"], 0, 5) == "/api/") {
                 $this->setActionName("error");

--- a/src/core/MVC/Controller.php
+++ b/src/core/MVC/Controller.php
@@ -46,7 +46,12 @@ class Controller extends Router {
 
     public function run() {
         if (($route = $this->parseUriRouter()) != null) {
-            if ($this->auth->canAccessProtectedRoute($route)) {
+            $puedeAcceder = $this->auth->canAccessProtectedRoute($route);
+            if ($puedeAcceder == null) {
+                $this->auth->noAuthGuard();
+                return false;
+            }
+            if ($puedeAcceder) {
                 $this->setResourceName($route["resource"]);
                 $this->setActionName($route["action"]);
             } else {


### PR DESCRIPTION
Issue #276 

Creado un AuthGuard para evitar que usuarios sin permiso entren en las rutas protegidas.

Las rutas públicas se declaran ` "nivelAuthGuard" => -1`
Las rutas privadas _(sólo* puede acceder un usuario registrado)_ se declaran ` "nivelAuthGuard" => 0`
Las rutas administrativas  _(sólo puede acceder un administrador)_ se declaran ` "nivelAuthGuard" => 9`

<hr>
*Sólo se hace la comprobación de si el usuario está registrado y la ruta es privada, en caso de necesitar asegurar que el usuario dueño del recurso es el mismo que hace la peticion, se encarga el resource.

_Ejemplo al editar un carrito:_

> juan está registrado

> puede modificar sus carritos, no puede modificar los de pepe

en este caso AuthGuard sólo asegura la 1º parte.

<hr>

Aviso: es posible que al hacer pruebas la base de datos haga cosas raras, esto es porque en la base está puesto 0 como admin y 9 como usuario, esto se cambiará en mi otro PR #269. Tenerlo en cuenta